### PR TITLE
Update render function to use local file when called by dw2pdf

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -105,9 +105,12 @@ class syntax_plugin_visrep extends DokuWiki_Syntax_Plugin {
     function render($format, &$R, $data) {
         if($format == 'xhtml') {
             $attrs = array();
-            
-            $url = DOKU_BASE.'lib/plugins/visrep/img.php?'.buildURLparams($data);
-            
+
+            if(is_a($R,'renderer_plugin_dw2pdf')){
+              $url = 'dw2pdf://'.$this->_imgfile($data);
+            } else {
+              $url = DOKU_BASE.'lib/plugins/visrep/img.php?'.buildURLparams($data);
+            }
             
             foreach ($data as $k=>$v) {
               if ($k == 'md5') continue;


### PR DESCRIPTION
Use dw2pdf pseudo protocol for images as described in dw2pdf docs:
https://www.dokuwiki.org/plugin:dw2pdf#for_developers

It's useful when HTTP-based authentication method is used (like Basic
Auth or certificates) and  mpdf is not able to fetch image over HTTP.
